### PR TITLE
Bugfix CONNACKv5 includes authentication method

### DIFF
--- a/src/main/java/com/hivemq/mqtt/handler/connect/ConnectHandler.java
+++ b/src/main/java/com/hivemq/mqtt/handler/connect/ConnectHandler.java
@@ -637,7 +637,8 @@ public class ConnectHandler extends SimpleChannelInboundHandler<CONNECT> impleme
                 .withWildcardSubscriptionAvailable(configurationService.mqttConfiguration().wildcardSubscriptionsEnabled())
                 .withSharedSubscriptionAvailable(configurationService.mqttConfiguration().sharedSubscriptionsEnabled())
                 .withMaximumQoS(configurationService.mqttConfiguration().maximumQos())
-                .withRetainAvailable(configurationService.mqttConfiguration().retainedMessagesEnabled());
+                .withRetainAvailable(configurationService.mqttConfiguration().retainedMessagesEnabled())
+                .withAuthMethod(msg.getAuthMethod());
 
         final boolean overridden = msg.getSessionExpiryInterval() > configuredSessionExpiryInterval;
         final long sessionExpiryInterval = overridden ? configuredSessionExpiryInterval : msg.getSessionExpiryInterval();


### PR DESCRIPTION
If client v5 authentication was successful, the returned CONNACK packet includes the same authentication method as the one specified by the client in the CONNECK message

**Motivation**

Resolves https://github.com/hivemq/hivemq-community-edition/issues/110

**Changes**
