### PR TITLE
Extended authentication support for broker and SDK

### DIFF
--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/auth/ExtendedAuthenticator.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/auth/ExtendedAuthenticator.java
@@ -1,0 +1,10 @@
+package com.hivemq.extension.sdk.api.auth;
+
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.auth.parameter.SimpleAuthInput;
+import com.hivemq.extension.sdk.api.auth.parameter.SimpleAuthOutput;
+
+@FunctionalInterface
+public interface ExtendedAuthenticator {
+    void onAUTH(@NotNull SimpleAuthInput simpleAuthInput, @NotNull SimpleAuthOutput connectAuthTaskOutput);
+}

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/auth/parameter/SimpleAuthInput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/auth/parameter/SimpleAuthInput.java
@@ -16,6 +16,8 @@
 
 package com.hivemq.extension.sdk.api.auth.parameter;
 
+import com.hivemq.extension.sdk.api.annotations.Nullable;
+import com.hivemq.extension.sdk.api.packets.auth.AUTHPacket;
 import com.hivemq.extension.sdk.api.packets.connect.ConnectPacket;
 import com.hivemq.extension.sdk.api.parameter.ClientBasedInput;
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;
@@ -41,4 +43,7 @@ public interface SimpleAuthInput extends ClientBasedInput {
      */
     @Immutable
     @NotNull ConnectPacket getConnectPacket();
+
+    @Immutable
+    @Nullable AUTHPacket getAuthPacket();
 }

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/auth/parameter/SimpleAuthOutput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/auth/parameter/SimpleAuthOutput.java
@@ -116,6 +116,12 @@ public interface SimpleAuthOutput extends AsyncOutput<SimpleAuthOutput> {
                                            @NotNull String reasonString);
 
     /**
+     *
+     * @param authenticationData to be included in the AUTH packet payload
+     */
+    void continueToAuth(@NotNull byte[] authenticationData);
+
+    /**
      * Fails the authentication for the client.
      * <p>
      * For an MQTT 3 client a CONNACK with connect return code <b>'Connection Refused, not authorized'</b> is sent.

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/auth/AUTHPacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/auth/AUTHPacket.java
@@ -1,0 +1,29 @@
+package com.hivemq.extension.sdk.api.packets.auth;
+
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.annotations.Nullable;
+
+import java.nio.ByteBuffer;
+
+public interface AUTHPacket {
+    /**
+     * The {@link ByteBuffer} contains the data used for the extended authentication.
+     * The contents of this data are defined by the authentication method.
+     *
+     * @return A {@link ByteBuffer} that contains the authentication data.
+     */
+    @NotNull ByteBuffer getAuthenticationData();
+
+    /**
+     * Contains the authentication method that is being used for the extended
+     * authentication.
+     *
+     * @return An {@link String} that contains the authentication method.
+     */
+    @NotNull String getAuthenticationMethod();
+
+    @Nullable String getReasonString();
+
+    @NotNull int getReasonCode();
+
+}

--- a/src/main/java/com/hivemq/extensions/packets/auth/AuthPacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/auth/AuthPacketImpl.java
@@ -1,0 +1,42 @@
+package com.hivemq.extensions.packets.auth;
+
+import com.hivemq.annotations.NotNull;
+import com.hivemq.extension.sdk.api.annotations.Nullable;
+import com.hivemq.extension.sdk.api.packets.auth.AUTHPacket;
+import com.hivemq.mqtt.message.auth.AUTH;
+
+import java.nio.ByteBuffer;
+
+public class AuthPacketImpl implements AUTHPacket {
+    private final ByteBuffer data;
+    private final String method;
+    private final int reasonCode;
+    private final String reasonString;
+
+    public AuthPacketImpl(@NotNull final AUTH auth) {
+        this.data = ByteBuffer.wrap(auth.getAuthData());
+        this.method = auth.getAuthMethod();
+        this.reasonCode = auth.getReasonCode().getCode();
+        this.reasonString = auth.getReasonString();
+    }
+
+    @Override
+    public @com.hivemq.extension.sdk.api.annotations.NotNull ByteBuffer getAuthenticationData() {
+        return data;
+    }
+
+    @Override
+    public @com.hivemq.extension.sdk.api.annotations.NotNull String getAuthenticationMethod() {
+        return method;
+    }
+
+    @Override
+    public @Nullable String getReasonString() {
+        return reasonString;
+    }
+
+    @Override
+    public @com.hivemq.extension.sdk.api.annotations.NotNull int getReasonCode() {
+        return reasonCode;
+    }
+}

--- a/src/main/java/com/hivemq/extensions/services/auth/ConnectAuthTaskInput.java
+++ b/src/main/java/com/hivemq/extensions/services/auth/ConnectAuthTaskInput.java
@@ -21,10 +21,13 @@ import com.hivemq.extension.sdk.api.annotations.Nullable;
 import com.hivemq.extension.sdk.api.auth.parameter.SimpleAuthInput;
 import com.hivemq.extension.sdk.api.client.parameter.ClientInformation;
 import com.hivemq.extension.sdk.api.client.parameter.ConnectionInformation;
+import com.hivemq.extension.sdk.api.packets.auth.AUTHPacket;
 import com.hivemq.extension.sdk.api.packets.connect.ConnectPacket;
 import com.hivemq.extensions.PluginInformationUtil;
 import com.hivemq.extensions.executor.task.PluginTaskInput;
+import com.hivemq.extensions.packets.auth.AuthPacketImpl;
 import com.hivemq.extensions.packets.connect.ConnectPacketImpl;
+import com.hivemq.mqtt.message.auth.AUTH;
 import com.hivemq.mqtt.message.connect.CONNECT;
 import io.netty.channel.ChannelHandlerContext;
 
@@ -40,6 +43,8 @@ public class ConnectAuthTaskInput implements Supplier<ConnectAuthTaskInput>, Plu
     private @Nullable ConnectPacket connectPacket;
     private final @NotNull ConnectionInformation connectionInformation;
     private final @NotNull ClientInformation clientInformation;
+    private @Nullable AUTHPacket auth;
+
 
     public ConnectAuthTaskInput(@NotNull final CONNECT connect,
                                 @NotNull final ChannelHandlerContext ctx) {
@@ -62,6 +67,15 @@ public class ConnectAuthTaskInput implements Supplier<ConnectAuthTaskInput>, Plu
             connectPacket = new ConnectPacketImpl(connect);
         }
         return connectPacket;
+    }
+
+    @Override
+    public @Nullable AUTHPacket getAuthPacket() {
+        return auth;
+    }
+
+    public void setAuth(final AUTH auth) {
+        this.auth = new AuthPacketImpl(auth);
     }
 
     @NotNull

--- a/src/main/java/com/hivemq/extensions/services/auth/ConnectAuthTaskOutput.java
+++ b/src/main/java/com/hivemq/extensions/services/auth/ConnectAuthTaskOutput.java
@@ -58,6 +58,7 @@ public class ConnectAuthTaskOutput extends AbstractAsyncOutput<SimpleAuthOutput>
     private @Nullable ConnackReasonCode connackReasonCode;
     private @Nullable String reasonString;
     private @NotNull ModifiableDefaultPermissions defaultPermissions;
+    private @NotNull byte[] authenticationData;
     private @NotNull
     final ModifiableClientSettingsImpl clientSettings;
 
@@ -164,6 +165,12 @@ public class ConnectAuthTaskOutput extends AbstractAsyncOutput<SimpleAuthOutput>
         authenticationState = AuthenticationState.CONTINUE;
     }
 
+    @Override
+    public void continueToAuth(final byte[] authenticationData) {
+        authenticationState = AuthenticationState.AUTH;
+        this.authenticationData = authenticationData;
+    }
+
     private void checkDecided(final @NotNull String method) {
         if (!decided.compareAndSet(false, true)) {
             throw new UnsupportedOperationException(method + " must not be called if authenticateSuccessfully, " +
@@ -227,7 +234,11 @@ public class ConnectAuthTaskOutput extends AbstractAsyncOutput<SimpleAuthOutput>
         return authenticatorPresent.get();
     }
 
+    public byte[] getAuthenticationData() {
+        return authenticationData;
+    }
+
     enum AuthenticationState {
-        SUCCESS, FAILED, CONTINUE, UNDECIDED
+        SUCCESS, FAILED, CONTINUE, UNDECIDED, AUTH
     }
 }

--- a/src/main/java/com/hivemq/mqtt/handler/auth/AuthHandler.java
+++ b/src/main/java/com/hivemq/mqtt/handler/auth/AuthHandler.java
@@ -16,12 +16,43 @@
 
 package com.hivemq.mqtt.handler.auth;
 
+import com.hivemq.annotations.NotNull;
+import com.hivemq.configuration.service.FullConfigurationService;
+import com.hivemq.extension.sdk.api.annotations.Immutable;
+import com.hivemq.extension.sdk.api.auth.parameter.AuthenticatorProviderInput;
+import com.hivemq.extension.sdk.api.auth.parameter.SimpleAuthInput;
+import com.hivemq.extension.sdk.api.client.parameter.ClientInformation;
+import com.hivemq.extension.sdk.api.client.parameter.ConnectionInformation;
+import com.hivemq.extension.sdk.api.packets.connect.ConnectPacket;
+import com.hivemq.extension.sdk.api.packets.general.DisconnectedReasonCode;
+import com.hivemq.extension.sdk.api.parameter.ClientBasedInput;
+import com.hivemq.extensions.client.parameter.AuthenticatorProviderInputFactory;
+import com.hivemq.extensions.events.OnAuthFailedEvent;
+import com.hivemq.extensions.executor.PluginOutPutAsyncer;
+import com.hivemq.extensions.executor.PluginTaskExecutorService;
+import com.hivemq.extensions.executor.task.PluginTaskInput;
+import com.hivemq.extensions.services.auth.*;
+import com.hivemq.mqtt.handler.connack.MqttConnacker;
 import com.hivemq.mqtt.message.auth.AUTH;
+import com.hivemq.mqtt.message.connack.Mqtt3ConnAckReturnCode;
+import com.hivemq.mqtt.message.connect.CONNECT;
+import com.hivemq.mqtt.message.reason.Mqtt5ConnAckReasonCode;
+import com.hivemq.util.ChannelAttributes;
+import com.hivemq.util.ReasonStrings;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 
+import javax.inject.Inject;
 import javax.inject.Singleton;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static com.hivemq.bootstrap.netty.ChannelHandlerNames.AUTH_IN_PROGRESS_MESSAGE_HANDLER;
+import static com.hivemq.bootstrap.netty.ChannelHandlerNames.MQTT_MESSAGE_DECODER;
+import static com.hivemq.configuration.service.InternalConfigurations.AUTH_DENY_UNAUTHENTICATED_CONNECTIONS;
+import static com.hivemq.mqtt.message.reason.Mqtt5AuthReasonCode.CONTINUE_AUTHENTICATION;
+import static com.hivemq.util.ChannelAttributes.AUTH_TASK_CONTEXT;
 
 /**
  * @author Lukas Brandl
@@ -29,9 +60,47 @@ import javax.inject.Singleton;
 @Singleton
 @ChannelHandler.Sharable
 public class AuthHandler extends SimpleChannelInboundHandler<AUTH> {
+    private final @NotNull Authenticators authenticators;
+    private final @NotNull PluginTaskExecutorService pluginTaskExecutorService;
+    private final @NotNull MqttConnacker mqttConnacker;
+    private final @NotNull PluginOutPutAsyncer asyncer;
+    private final @NotNull FullConfigurationService configurationService;
+    private final @NotNull AuthenticatorProviderInputFactory authenticatorProviderInputFactory;
+
+    @Inject
+    public AuthHandler(
+            final @NotNull Authenticators authenticators,
+            final @NotNull PluginTaskExecutorService pluginTaskExecutorService,
+            final @NotNull MqttConnacker mqttConnacker,
+            final @NotNull PluginOutPutAsyncer asyncer,
+            final @NotNull FullConfigurationService configurationService,
+            final @NotNull AuthenticatorProviderInputFactory authenticatorProviderInputFactory) {
+        this.authenticators = authenticators;
+        this.pluginTaskExecutorService = pluginTaskExecutorService;
+        this.mqttConnacker = mqttConnacker;
+        this.asyncer = asyncer;
+        this.configurationService = configurationService;
+        this.authenticatorProviderInputFactory = authenticatorProviderInputFactory;
+    }
 
     @Override
     protected void channelRead0(final ChannelHandlerContext ctx, final AUTH msg) throws Exception {
-        // Ignore auth messages for now
+        final Map<String, WrappedAuthenticatorProvider> authenticatorProviderMap = authenticators.getAuthenticatorProviderMap();
+        final String authMethod = msg.getAuthMethod();
+        assert authMethod.equals(ctx.channel().attr(ChannelAttributes.AUTH_METHOD).get());
+        final ConnectAuthTaskContext context = ctx.channel().attr(AUTH_TASK_CONTEXT).get();
+        final CONNECT connect = context.getConnect();
+
+        final ConnectAuthTaskInput input = new ConnectAuthTaskInput(connect, ctx);
+        input.setAuth(msg);
+        final AuthenticatorProviderInput
+                authenticatorProviderInput = authenticatorProviderInputFactory.createInput(ctx, connect.getClientIdentifier());
+
+        for (final WrappedAuthenticatorProvider wrapped : authenticatorProviderMap.values()) {
+
+            pluginTaskExecutorService.handlePluginInOutTaskExecution(
+                    context, input, context, new SimpleAuthTask(wrapped, authenticatorProviderInput));
+        }
     }
+
 }

--- a/src/main/java/com/hivemq/mqtt/handler/connect/ConnectHandler.java
+++ b/src/main/java/com/hivemq/mqtt/handler/connect/ConnectHandler.java
@@ -257,7 +257,7 @@ public class ConnectHandler extends SimpleChannelInboundHandler<CONNECT> impleme
         final ConnectAuthTaskContext context =
                 new ConnectAuthTaskContext(connect.getClientIdentifier(), this, mqttConnacker, ctx, connect, asyncer,
                         authenticatorProviderMap.size(), configurationService.securityConfiguration().validateUTF8(), createClientSettings(connect));
-
+        ctx.channel().attr(ChannelAttributes.AUTH_TASK_CONTEXT).set(context);
         final AuthenticatorProviderInput authenticatorProviderInput = authenticatorProviderInputFactory.createInput(ctx, connect.getClientIdentifier());
 
         for (final WrappedAuthenticatorProvider wrapped : authenticatorProviderMap.values()) {

--- a/src/main/java/com/hivemq/mqtt/handler/connect/MessageBarrier.java
+++ b/src/main/java/com/hivemq/mqtt/handler/connect/MessageBarrier.java
@@ -21,6 +21,7 @@ import com.google.inject.Inject;
 import com.hivemq.annotations.NotNull;
 import com.hivemq.logging.EventLog;
 import com.hivemq.mqtt.message.Message;
+import com.hivemq.mqtt.message.auth.AUTH;
 import com.hivemq.mqtt.message.connack.CONNACK;
 import com.hivemq.mqtt.message.connect.CONNECT;
 import com.hivemq.mqtt.message.reason.Mqtt5ConnAckReasonCode;
@@ -74,7 +75,7 @@ public class MessageBarrier extends ChannelDuplexHandler {
                 }
                 return;
 
-            } else if (connectAlreadySent.get() && !connackAlreadySent.get()) {
+            } else if (connectAlreadySent.get() && !connackAlreadySent.get() && !(msg instanceof AUTH)) {
                 messageQueue.add((Message) msg);
                 return;
             }

--- a/src/main/java/com/hivemq/util/ChannelAttributes.java
+++ b/src/main/java/com/hivemq/util/ChannelAttributes.java
@@ -26,6 +26,7 @@ import com.hivemq.extensions.client.ClientAuthorizers;
 import com.hivemq.extensions.client.ClientContextImpl;
 import com.hivemq.extensions.client.parameter.ConnectionAttributes;
 import com.hivemq.extensions.events.client.parameters.ClientEventListeners;
+import com.hivemq.extensions.services.auth.ConnectAuthTaskContext;
 import com.hivemq.mqtt.message.ProtocolVersion;
 import com.hivemq.mqtt.message.connect.CONNECT;
 import com.hivemq.mqtt.message.mqtt5.Mqtt5UserProperties;
@@ -134,6 +135,7 @@ public class ChannelAttributes {
     public static final AttributeKey<ModifiableDefaultPermissions> AUTH_PERMISSIONS = AttributeKey.valueOf("Auth.User.Permissions");
 
     public static final AttributeKey<CONNECT> CONNECT_MESSAGE = AttributeKey.valueOf("Connect.Message");
+    public static final AttributeKey<ConnectAuthTaskContext> AUTH_TASK_CONTEXT = AttributeKey.valueOf("Connect.Context");
 
     /**
      * True if this client is not allowed to publish any more messages, if <null> he is allowed to do so.


### PR DESCRIPTION
Added SDK interfaces to support extensions implementing features on top of extended v5 authentication and modified the broker to support sending and receiving AUTH packets and forwarding them to the extensions

**Motivation**
Allow users to take advantage of the new enhanced authentication features that are already implemented in the broker, just not exposed

**Changes**
SDK:
- New interfaces to expose AUTH packet fields
- New interface to allow extending enhanced authenticators
Broker changes:
- allow Enhanced Authenticators request authentication continue, where the broker sends an Auth packet back to the client
- allow broker to receive AUTH response and channel it back to the extension to continue from there